### PR TITLE
Fix recursion by checking for sign materials instead of state, since state causes a weird hell with lit furnaces that causes infinite recursion.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.Acrobot.ChestShop</groupId>
     <artifactId>ChestShop</artifactId>
-    <version>3.14</version>
+    <version>3.15</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/blockPhysics.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/blockPhysics.java
@@ -5,10 +5,11 @@ import io.wesner.robert.cb1060.RDEB;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.Sign;
+import org.bukkit.craftbukkit.block.CraftSign;
 import org.bukkit.event.block.BlockListener;
 import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.material.Attachable;
+import org.bukkit.material.Sign;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,7 +34,7 @@ public class blockPhysics extends BlockListener {
                 return;
             }
 
-            if (shouldCancel(event.getBlock().getRelative(BlockFace.UP))) {
+            if (shouldCancel(event.getBlock().getRelative(BlockFace.UP), BlockFace.DOWN)) {
                 event.setCancelled(true);
 
                 return;
@@ -49,7 +50,7 @@ public class blockPhysics extends BlockListener {
                 Block neighbor = event.getBlock().getRelative(face);
                 if (neighbor.getState() != null && (neighbor.getState().getData() instanceof Attachable)) {
                     Attachable data = (Attachable) neighbor.getState().getData();
-                    if (data.getAttachedFace() == face.getOppositeFace() && shouldCancel(neighbor)) {
+                    if (data.getAttachedFace() == face.getOppositeFace() && shouldCancel(neighbor, face.getOppositeFace())) {
                         event.setCancelled(true);
 
                         return;
@@ -61,7 +62,16 @@ public class blockPhysics extends BlockListener {
         }
     }
 
-    private boolean shouldCancel(Block block) {
-        return uSign.isSign(block) && uSign.isValid((Sign) block.getState());
+    private boolean shouldCancel(Block block, BlockFace expectedAttachedTo) {
+        if (!uSign.isSign(block)) {
+            return false;
+        }
+
+        CraftSign state = (CraftSign) block.getState();
+        if (!uSign.isValid(state)) {
+            return false;
+        }
+
+        return ((Sign) state.getData()).getAttachedFace() == expectedAttachedTo;
     }
 }

--- a/src/main/java/com/Acrobot/ChestShop/Utils/uSign.java
+++ b/src/main/java/com/Acrobot/ChestShop/Utils/uSign.java
@@ -2,6 +2,7 @@ package com.Acrobot.ChestShop.Utils;
 
 import com.Acrobot.ChestShop.Config.Config;
 import com.Acrobot.ChestShop.Config.Property;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 
@@ -26,7 +27,8 @@ public class uSign {
     };
 
     public static boolean isSign(Block block) {
-        return block.getState() instanceof Sign;
+        // DO NOT CALL block.getState() here if you value your life! It causes infinite recursion because ChestShop is jank!
+        return block.getType() == Material.SIGN_POST || block.getType() == Material.WALL_SIGN;
     }
 
     public static boolean isAdminShop(String owner) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: ChestShop
 
 main: com.Acrobot.ChestShop.ChestShop
 
-version: 3.12
+version: 3.15
 
 
 author: Acrobot


### PR DESCRIPTION
RDEB should only be dropped once we are >=99.9% sure it is no longer needed, lest the server blows up again.